### PR TITLE
Allow command blocks to run commands 

### DIFF
--- a/src/main/java/dev/gigaherz/playertemplate/PlayerTemplateMod.java
+++ b/src/main/java/dev/gigaherz/playertemplate/PlayerTemplateMod.java
@@ -63,7 +63,7 @@ public class PlayerTemplateMod
     {
         event.getDispatcher().register(
                 LiteralArgumentBuilder.<CommandSourceStack>literal("playertemplate")
-                        .requires(cs->cs.hasPermission(4)) //permission
+                        .requires(cs->cs.hasPermission(2)) //permission
                         .then(Commands.literal("apply")
                                 .then(Commands.argument("players", EntityArgument.players())
                                         .then(Commands.literal("wipe")

--- a/src/main/java/dev/gigaherz/playertemplate/PlayerTemplateMod.java
+++ b/src/main/java/dev/gigaherz/playertemplate/PlayerTemplateMod.java
@@ -63,7 +63,7 @@ public class PlayerTemplateMod
     {
         event.getDispatcher().register(
                 LiteralArgumentBuilder.<CommandSourceStack>literal("playertemplate")
-                        .requires(cs->cs.hasPermission(2)) //permission
+                        .requires(cs->cs.hasPermission(Commands.GAMEMASTERS)) //permission
                         .then(Commands.literal("apply")
                                 .then(Commands.argument("players", EntityArgument.players())
                                         .then(Commands.literal("wipe")


### PR DESCRIPTION
This PR lowers the permission requirement for the player template commands to 2 instead of 4, to allow command blocks to run the command as well. 